### PR TITLE
Fix IODListLoaderWorker to use nested emit_percent for progress callback

### DIFF
--- a/src/dcmspec_explorer/services/iod_loading_service.py
+++ b/src/dcmspec_explorer/services/iod_loading_service.py
@@ -11,13 +11,6 @@ class IODListLoaderWorker(QObject):
     error = Signal(str)
     progress = Signal(int)
 
-    def emit_percent(self, progress):
-        """Define callback function to receive progress updates.
-
-        This function will emit a custom signal with the progress percentage.
-        """
-        self.progress.emit(progress.percent)
-
     def __init__(self, model, logger):
         """Initialize the worker with the model to load IOD list."""
         super().__init__()
@@ -43,7 +36,7 @@ class IODListLoaderWorker(QObject):
             self.progress.emit(percent)
 
         try:
-            iod_modules = self.model.load_iod_list(progress_callback=self.emit_percent)
+            iod_modules = self.model.load_iod_list(progress_callback=emit_percent)
             self.finished.emit(iod_modules)
         except Exception as e:
             self.error.emit(str(e))


### PR DESCRIPTION
- Remove obsolete class-level emit_percent method
- Pass nested emit_percent function to load_iod_list as progress_callback