### PR TITLE
Implement version-aware Reload from web

### DIFF
--- a/src/dcmspec_explorer/controller/app_controller.py
+++ b/src/dcmspec_explorer/controller/app_controller.py
@@ -102,6 +102,7 @@ class AppController(QObject):
         self.view.iod_treeview_right_click.connect(self._on_treeview_right_click)
         self.view.ui.detailsTextBrowser.anchorClicked.connect(self._on_details_link_clicked)
         self.view.toggle_favorites_clicked.connect(self._on_toggle_favorites_clicked)
+        self.view.reload_clicked.connect(self._on_reload_clicked)
 
         # Initialize sorting state
         self.sort_column: Optional[int] = None  # No sorting on first load
@@ -123,14 +124,8 @@ class AppController(QObject):
         # Start the worker in a background thread via the service mediator
         self._treeview_worker, self._treeview_thread = self.service.start_iodlist_worker()
 
-        # Connect service mediator's Qt signals to UI update methods.
-        # By specifying Qt.QueuedConnection, we ensure that if a signal is emitted from any thread,
-        # the connected slot (UI update method) will be executed in the thread that owns the receiver object.
-        # In this case, both the ServiceMediator and AppController live in the main thread, so UI updates
-        # are performed in the main thread, ensuring thread safety for all Qt UI operations.
-        self.service.iodlist_progress_signal.connect(self._handle_iodlist_progress, Qt.QueuedConnection)
-        self.service.iodlist_loaded_signal.connect(self._handle_iodlist_loaded, Qt.QueuedConnection)
-        self.service.iodlist_error_signal.connect(self._handle_iodlist_error, Qt.QueuedConnection)
+        # Connect signals for progress, loaded, and error
+        self._connect_iodlist_signals()
 
     def _on_search_text_changed(self, text: str) -> None:
         """Handle search box text change and update filtering."""
@@ -193,6 +188,15 @@ class AppController(QObject):
         action.triggered.connect(lambda: self._toggle_favorite(table_id))
         menu.exec(global_pos)
 
+    def _on_reload_clicked(self):
+        """Handle Reload button click: reload IOD list from the web."""
+        self.logger.info("Reload button clicked: reloading IOD list from web.")
+        self.view.update_status_bar(message="Downloading latest IOD modules from web...")
+        # Start the worker in a background thread via the service mediator, forcing download
+        self._treeview_worker, self._treeview_thread = self.service.start_iodlist_worker(force_download=True)
+        # Connect signals for progress, loaded, and error
+        self._connect_iodlist_signals()
+
     def _toggle_favorite(self, table_id):
         try:
             if self.favorites_manager.is_favorite(table_id):
@@ -224,6 +228,22 @@ class AppController(QObject):
             for sig in signals:
                 with contextlib.suppress(TypeError):
                     sig.disconnect()
+
+    def _connect_iodlist_signals(self):
+        """(Re)connect IOD list loader signals to their handlers, safely disconnecting first."""
+        self._safe_disconnect(
+            self.service.iodlist_progress_signal,
+            self.service.iodlist_loaded_signal,
+            self.service.iodlist_error_signal,
+        )
+        # Connect service mediator's Qt signals to UI update methods.
+        # By specifying Qt.QueuedConnection, we ensure that if a signal is emitted from any thread,
+        # the connected slot (UI update method) will be executed in the thread that owns the receiver object.
+        # In this case, both the ServiceMediator and AppController live in the main thread, so UI updates
+        # are performed in the main thread, ensuring thread safety for all Qt UI operations.
+        self.service.iodlist_progress_signal.connect(self._handle_iodlist_progress, Qt.QueuedConnection)
+        self.service.iodlist_loaded_signal.connect(self._handle_iodlist_loaded, Qt.QueuedConnection)
+        self.service.iodlist_error_signal.connect(self._handle_iodlist_error, Qt.QueuedConnection)
 
     def _handle_iod_item_clicked(
         self, index: QModelIndex, selected_item_name: QStandardItem, selected_item_kind: QStandardItem
@@ -329,11 +349,25 @@ class AppController(QObject):
             self.view.update_status_bar(f"Loading IOD modules... {percent}%")
 
     def _handle_iodlist_loaded(self, sender: object, iod_entry_list: list[IODEntry]) -> None:
-        # Initialize the mapping of already loaded iods (AnyTree node content added to treeview) by their table_id
+        # Save the mapping of already loaded iods (AnyTree node content added to treeview) by their table_id
+        loaded_children = getattr(self, "_iod_children_loaded", {}).copy()
+
+        # Initialize the mapping for this session
         self._iod_children_loaded = {}
 
         # Populate the tree model with the loaded IODs applying filters and sorting
         self.apply_filter_and_sort(iod_entry_list=iod_entry_list)
+
+        # After repopulating the treeview, re-add children for IODs by reloading from the model
+        if not self.model.new_version_available:
+            model = self.view.ui.iodTreeView.model()
+            for table_id in loaded_children.keys():
+                # Reload the IOD model (from cache if available)
+                iod_model = self.model.load_iod_model(table_id, self.logger)
+                if iod_model and hasattr(iod_model, "content") and iod_model.content:
+                    self.model.add_iod_spec_content(table_id, iod_model.content)
+                    IODTreeViewModelAdapter.populate_iod_entry_children(model, table_id, iod_model.content)
+                    self._iod_children_loaded[table_id] = iod_model.content
 
         # Update the version label with the model's version
         if self.model.version:

--- a/src/dcmspec_explorer/model/model.py
+++ b/src/dcmspec_explorer/model/model.py
@@ -472,19 +472,36 @@ class Model:
                 self.logger.warning(f"Failed to move existing archive {versioned_dir} to {backup_dir}: {e}")
 
         # Move the entire standard folder if it exists
-        if os.path.exists(standard_cache_dir):
-            os.makedirs(versioned_dir, exist_ok=True)
-            try:
-                shutil.move(standard_cache_dir, versioned_standard_dir)
-                self.logger.info(f"Moved standard cache folder to versioned folder: {versioned_standard_dir}")
-            except Exception as e:
-                self.logger.warning(f"Failed to move {standard_cache_dir} to {versioned_standard_dir}: {e}")
+        self._move_folder_if_exists(
+            src=standard_cache_dir,
+            dst=versioned_standard_dir,
+            ensure_parent=versioned_dir,
+            description="standard cache folder to versioned folder",
+        )
 
         # Move the entire model folder if it exists
-        if os.path.exists(model_cache_dir):
-            os.makedirs(versioned_dir, exist_ok=True)
+        self._move_folder_if_exists(
+            src=model_cache_dir,
+            dst=versioned_model_dir,
+            ensure_parent=versioned_dir,
+            description="model cache folder to versioned folder",
+        )
+
+    def _move_folder_if_exists(self, src: str, dst: str, ensure_parent: str = None, description: str = "") -> None:
+        """Move a folder from src to dst if it exists, creating parent if needed, and log the result.
+
+        Args:
+            src (str): Source folder path.
+            dst (str): Destination folder path.
+            ensure_parent (str, optional): Parent directory to create before moving.
+            description (str, optional): Description for logging.
+
+        """
+        if os.path.exists(src):
+            if ensure_parent:
+                os.makedirs(ensure_parent, exist_ok=True)
             try:
-                shutil.move(model_cache_dir, versioned_model_dir)
-                self.logger.info(f"Moved model cache folder to versioned folder: {versioned_model_dir}")
+                shutil.move(src, dst)
+                self.logger.info(f"Moved {description}: {src} -> {dst}")
             except Exception as e:
-                self.logger.warning(f"Failed to move {model_cache_dir} to {versioned_model_dir}: {e}")
+                self.logger.warning(f"Failed to move {description}: {src} -> {dst}: {e}")

--- a/src/dcmspec_explorer/model/model.py
+++ b/src/dcmspec_explorer/model/model.py
@@ -83,6 +83,21 @@ class Model:
             return []
         return [IODEntry(node.name, node.table_id, node.table_url, node.iod_kind) for node in self._iod_dict.values()]
 
+    def _standard_cache_dir(self) -> str:
+        return os.path.join(self.config.cache_dir, "standard")
+
+    def _model_cache_dir(self) -> str:
+        return os.path.join(self.config.cache_dir, "model")
+
+    def _versioned_dir(self, version: str) -> str:
+        return os.path.join(self.config.cache_dir, version)
+
+    def _versioned_standard_dir(self, version: str) -> str:
+        return os.path.join(self._versioned_dir(version), "standard")
+
+    def _versioned_model_dir(self, version: str) -> str:
+        return os.path.join(self._versioned_dir(version), "model")
+
     def load_iod_list(
         self, force_download: bool = False, progress_observer: ServiceProgressObserver = None
     ) -> List[IODEntry]:
@@ -108,20 +123,19 @@ class Model:
         self.logger.debug("Loading IOD list...")
 
         cache_file_name = "ps3.3.html"
-        standard_cache_dir = os.path.join(self.config.cache_dir, "standard")
 
         try:
             # Step 1: Prepare temp file if needed
             temp_file_name, temp_file_path = (None, None)
             if force_download:
-                temp_file_name, temp_file_path = self._create_temp_iod_list_file(standard_cache_dir)
+                temp_file_name, temp_file_path = self._create_temp_iod_list_file()
 
             # Step 2. Download or read cache in temp or cache file in cache/standard folder
             soup = self._load_iod_list_html(force_download, cache_file_name, temp_file_name, progress_observer)
 
             # Step 3. If force_download, move the temp file to cache root to protect it from archiving
             if force_download and temp_file_name:
-                temp_file_path = self._move_temp_file_to_cache_root(standard_cache_dir, temp_file_name)
+                temp_file_path = self._move_temp_file_to_cache_root(temp_file_name)
 
             # Step 4: Parse the IOD list and version from the HTML
             iod_entry_list, version = self._parse_iod_list_from_html(soup)
@@ -135,7 +149,7 @@ class Model:
 
             # Step 7: If a temp file was used, move it to the canonical location after archiving/version handling
             if force_download and temp_file_path:
-                self._move_temp_iod_list_to_cache(temp_file_path, standard_cache_dir, cache_file_name)
+                self._move_temp_iod_list_to_cache(temp_file_path, cache_file_name)
 
             # Step 8: Update the in-memory model and version
             self._version = version
@@ -145,183 +159,6 @@ class Model:
             error_msg = f"Failed to load DICOM specification: \n{str(e)}"
             self.logger.error(error_msg)
             raise RuntimeError(error_msg) from e
-
-        return iod_entry_list
-
-    def _detect_version_changed(self, new_version: str) -> bool:
-        """Detect if the DICOM version has changed compared to the current version.
-
-        Args:
-            new_version (str): The new DICOM version string.
-
-        Returns:
-            bool: True if the version has changed, False otherwise.
-
-        """
-        return self._version is not None and self._version != new_version
-
-    def _create_temp_iod_list_file(self, standard_cache_dir: str) -> Tuple[str, str]:
-        """Create a unique temp file for downloading the IOD list file in the standard cache directory.
-
-        Returns:
-            Tuple[str, str]: (temp_file_name, temp_file_path)
-
-        """
-        with tempfile.NamedTemporaryFile(delete=False, dir=standard_cache_dir, suffix=".html") as tmp:
-            temp_file_name = os.path.basename(tmp.name)
-            temp_file_path = tmp.name
-        return temp_file_name, temp_file_path
-
-    def _load_iod_list_html(
-        self,
-        force_download: bool,
-        cache_file_name: str,
-        temp_file_name: str = None,
-        progress_observer: ServiceProgressObserver = None,
-    ) -> BeautifulSoup:
-        """Download or load the IOD list HTML from cache, using a temp file if force_download is True.
-
-        This method only handles loading (download or cache read), not parsing.
-
-        Returns:
-            BeautifulSoup: The loaded HTML soup.
-
-        """
-        if not force_download or not temp_file_name:
-            return self.doc_handler.load_document(
-                cache_file_name=cache_file_name,
-                url=self.part3_toc_url,
-                force_download=False,
-                progress_observer=progress_observer,
-            )
-        return self.doc_handler.load_document(
-            cache_file_name=temp_file_name,
-            url=self.part3_toc_url,
-            force_download=True,
-            progress_observer=progress_observer,
-        )
-
-    def _move_temp_file_to_cache_root(self, standard_cache_dir: str, temp_file_name: str) -> str:
-        """Move the temp file from cache/standard to cache root and return the new path."""
-        cache_root_temp_path = os.path.join(self.config.cache_dir, temp_file_name)
-        src_path = os.path.join(standard_cache_dir, temp_file_name)
-        try:
-            shutil.move(src_path, cache_root_temp_path)
-            return cache_root_temp_path
-        except Exception as e:
-            self.logger.warning(f"Failed to move temp IOD list file from cache/standard to cache root: {e}")
-            return src_path
-
-    def _parse_iod_list_from_html(self, soup: BeautifulSoup) -> Tuple[List[IODEntry], str]:
-        """Parse the HTML soup, extract IOD list and version.
-
-        Args:
-            soup: BeautifulSoup object of the loaded HTML.
-
-        Returns:
-            Tuple[List[IODEntry], str]: A tuple of (IODEntry list, version string).
-
-        """
-        # Extract DICOM standard version
-        version = self.dom_parser.get_version(soup, "")
-
-        # Find the list of tables section
-        list_of_tables = soup.find("div", class_="list-of-tables")
-        if not list_of_tables:
-            error_msg = "Could not find list-of-tables section in downloaded HTML document."
-            self.logger.error(error_msg)
-            raise ValueError(error_msg)
-
-        # Extract IOD list from the list of tables section
-        iod_entry_list = self._extract_iod_list(list_of_tables)
-
-        return iod_entry_list, version
-
-    def _move_temp_iod_list_to_cache(self, temp_file_path: str, standard_cache_dir: str, cache_file_name: str) -> None:
-        """Move the temp IOD list file to the canonical cache location after archiving/version handling."""
-        cache_file_path = os.path.join(standard_cache_dir, cache_file_name)
-        if not os.path.exists(standard_cache_dir):
-            os.makedirs(standard_cache_dir, exist_ok=True)
-        try:
-            shutil.move(temp_file_path, cache_file_path)
-        except Exception as e:
-            self.logger.warning(f"Failed to move temp IOD list file to {cache_file_path}: {e}")
-
-    def _build_iods_model(self, iod_entry_list: List[IODEntry]):
-        """Build a tree model for IODs and a dict mapping table_id to IOD nodes.
-
-        The tree structure supports later addition of modules and attributes as children of each IOD node.
-        The dict allows fast lookup of IOD nodes by table_id.
-
-        Args:
-            iod_entry_list (List[IODEntry]): List of IODEntry objects.
-
-        Returns:
-            Tuple[Any, dict]: (iod_root, iod_dict)
-                iod_root: The AnyTree root node for all IODs.
-                iod_dict: Dict mapping table_id to the corresponding IOD node.
-
-        """
-        iod_root = Node("IOD List")
-        iod_dict = {}
-        for iod in iod_entry_list:
-            # Create a node for each IOD and attach it to the root
-            iod_node = Node(
-                iod.name, parent=iod_root, table_id=iod.table_id, table_url=iod.table_url, iod_kind=iod.kind
-            )
-            # Store the node in the dict for fast lookup by table_id
-            iod_dict[iod.table_id] = iod_node
-        return iod_root, iod_dict
-
-    def _extract_iod_list(self, list_of_tables) -> List[IODEntry]:
-        """Extract list of IODs from the list of tables section.
-
-        Returns:
-            List[IODEntry]: A list of IODEntry objects.
-
-        """
-        # Compute the base URL by stripping the filename from part3_toc_url
-        base_url = self.part3_toc_url.rsplit("/", 1)[0] + "/"
-        iod_entry_list = []
-
-        # Find all dt elements
-        dt_elements = list_of_tables.find_all("dt")
-
-        for dt in dt_elements:
-            # Find anchor tags within the dt
-            anchor = dt.find("a")
-            if anchor and anchor.get("href"):
-                # in the chunked HTML document ps3.3.html list of table anchors, hrefs are of the form filename#table_id
-                href = anchor.get("href")
-                text = anchor.get_text(strip=True)
-
-                # Check if this is an IOD Modules table
-                if "IOD Modules" in text:
-                    # Extract table ID from href (after the #)
-                    if "#" in href:
-                        table_id = href.split("#")[-1]
-                        table_url = urljoin(base_url, href)
-                    else:
-                        table_id = "table_id_not_found"
-                        self.logger.warning(f"Table ID not found in href: {href}")
-
-                    # Extract the title (remove the table number prefix)
-                    title_match = re.match(r"^[A-Z]?\.\d+(?:\.\d+)*-\d+\.\s*(.+)$", text)
-                    title = title_match[1] if title_match else text
-
-                    # Strip " IOD Modules" from the end of the title
-                    if title.endswith(" IOD Modules"):
-                        iod_name = title[:-12]  # Remove " IOD Modules" (12 characters)
-
-                    # Determine IOD kind based on table_id
-                    if "_A." in table_id:
-                        iod_kind = "Composite"
-                    elif "_B." in table_id:
-                        iod_kind = "Normalized"
-                    else:
-                        iod_kind = "Other"
-
-                    iod_entry_list.append(IODEntry(iod_name, table_id, table_url, iod_kind))
 
         return iod_entry_list
 
@@ -445,6 +282,105 @@ class Model:
         node = self.get_node_by_path(node_path)
         return None if node is None else node.__dict__
 
+    def _create_temp_iod_list_file(self) -> Tuple[str, str]:
+        """Create a unique temp file for downloading the IOD list file in the standard cache directory.
+
+        Returns:
+            Tuple[str, str]: (temp_file_name, temp_file_path)
+
+        """
+        with tempfile.NamedTemporaryFile(delete=False, dir=self._standard_cache_dir(), suffix=".html") as tmp:
+            temp_file_name = os.path.basename(tmp.name)
+            temp_file_path = tmp.name
+        return temp_file_name, temp_file_path
+
+    def _load_iod_list_html(
+        self,
+        force_download: bool,
+        cache_file_name: str,
+        temp_file_name: str = None,
+        progress_observer: ServiceProgressObserver = None,
+    ) -> BeautifulSoup:
+        """Download or load the IOD list HTML from cache, using a temp file if force_download is True.
+
+        This method only handles loading (download or cache read), not parsing.
+
+        Returns:
+            BeautifulSoup: The loaded HTML soup.
+
+        """
+        if not force_download or not temp_file_name:
+            return self.doc_handler.load_document(
+                cache_file_name=cache_file_name,
+                url=self.part3_toc_url,
+                force_download=False,
+                progress_observer=progress_observer,
+            )
+        return self.doc_handler.load_document(
+            cache_file_name=temp_file_name,
+            url=self.part3_toc_url,
+            force_download=True,
+            progress_observer=progress_observer,
+        )
+
+    def _move_temp_file_to_cache_root(self, temp_file_name: str) -> str:
+        """Move the temp file from cache/standard to cache root and return the new path."""
+        cache_root_temp_path = os.path.join(self.config.cache_dir, temp_file_name)
+        src_path = os.path.join(self._standard_cache_dir(), temp_file_name)
+        try:
+            shutil.move(src_path, cache_root_temp_path)
+            return cache_root_temp_path
+        except Exception as e:
+            self.logger.warning(f"Failed to move temp IOD list file from cache/standard to cache root: {e}")
+            return src_path
+
+    def _parse_iod_list_from_html(self, soup: BeautifulSoup) -> Tuple[List[IODEntry], str]:
+        """Parse the HTML soup, extract IOD list and version.
+
+        Args:
+            soup: BeautifulSoup object of the loaded HTML.
+
+        Returns:
+            Tuple[List[IODEntry], str]: A tuple of (IODEntry list, version string).
+
+        """
+        # Extract DICOM standard version
+        version = self.dom_parser.get_version(soup, "")
+
+        # Find the list of tables section
+        list_of_tables = soup.find("div", class_="list-of-tables")
+        if not list_of_tables:
+            error_msg = "Could not find list-of-tables section in downloaded HTML document."
+            self.logger.error(error_msg)
+            raise ValueError(error_msg)
+
+        # Extract IOD list from the list of tables section
+        iod_entry_list = self._extract_iod_list(list_of_tables)
+
+        return iod_entry_list, version
+
+    def _detect_version_changed(self, new_version: str) -> bool:
+        """Detect if the DICOM version has changed compared to the current version.
+
+        Args:
+            new_version (str): The new DICOM version string.
+
+        Returns:
+            bool: True if the version has changed, False otherwise.
+
+        """
+        return self._version is not None and self._version != new_version
+
+    def _move_temp_iod_list_to_cache(self, temp_file_path: str, cache_file_name: str) -> None:
+        """Move the temp IOD list file to the canonical cache location after archiving/version handling."""
+        cache_file_path = os.path.join(self._standard_cache_dir(), cache_file_name)
+        if not os.path.exists(self._standard_cache_dir()):
+            os.makedirs(self._standard_cache_dir(), exist_ok=True)
+        try:
+            shutil.move(temp_file_path, cache_file_path)
+        except Exception as e:
+            self.logger.warning(f"Failed to move temp IOD list file to {cache_file_path}: {e}")
+
     def _archive_previous_version_cache(self):
         """Move the entire standard and model cache folders to a versioned cache/<old_version>/ folder."""
         prev_version = self._version
@@ -452,12 +388,11 @@ class Model:
             self.logger.info("No previous version found; skipping cache move.")
             return
 
-        cache_dir = self.config.cache_dir
-        versioned_dir = os.path.join(cache_dir, prev_version)
-        standard_cache_dir = os.path.join(cache_dir, "standard")
-        model_cache_dir = os.path.join(cache_dir, "model")
-        versioned_standard_dir = os.path.join(versioned_dir, "standard")
-        versioned_model_dir = os.path.join(versioned_dir, "model")
+        versioned_dir = self._versioned_dir(prev_version)
+        standard_cache_dir = self._standard_cache_dir()
+        model_cache_dir = self._model_cache_dir()
+        versioned_standard_dir = self._versioned_standard_dir(prev_version)
+        versioned_model_dir = self._versioned_model_dir(prev_version)
 
         # If the versioned archive already exists, move it to a timestamped backup folder
         if os.path.exists(versioned_dir):
@@ -505,3 +440,81 @@ class Model:
                 self.logger.info(f"Moved {description}: {src} -> {dst}")
             except Exception as e:
                 self.logger.warning(f"Failed to move {description}: {src} -> {dst}: {e}")
+
+    def _build_iods_model(self, iod_entry_list: List[IODEntry]):
+        """Build a tree model for IODs and a dict mapping table_id to IOD nodes.
+
+        The tree structure supports later addition of modules and attributes as children of each IOD node.
+        The dict allows fast lookup of IOD nodes by table_id.
+
+        Args:
+            iod_entry_list (List[IODEntry]): List of IODEntry objects.
+
+        Returns:
+            Tuple[Any, dict]: (iod_root, iod_dict)
+                iod_root: The AnyTree root node for all IODs.
+                iod_dict: Dict mapping table_id to the corresponding IOD node.
+
+        """
+        iod_root = Node("IOD List")
+        iod_dict = {}
+        for iod in iod_entry_list:
+            # Create a node for each IOD and attach it to the root
+            iod_node = Node(
+                iod.name, parent=iod_root, table_id=iod.table_id, table_url=iod.table_url, iod_kind=iod.kind
+            )
+            # Store the node in the dict for fast lookup by table_id
+            iod_dict[iod.table_id] = iod_node
+        return iod_root, iod_dict
+
+    def _extract_iod_list(self, list_of_tables) -> List[IODEntry]:
+        """Extract list of IODs from the list of tables section.
+
+        Returns:
+            List[IODEntry]: A list of IODEntry objects.
+
+        """
+        # Compute the base URL by stripping the filename from part3_toc_url
+        base_url = self.part3_toc_url.rsplit("/", 1)[0] + "/"
+        iod_entry_list = []
+
+        # Find all dt elements
+        dt_elements = list_of_tables.find_all("dt")
+
+        for dt in dt_elements:
+            # Find anchor tags within the dt
+            anchor = dt.find("a")
+            if anchor and anchor.get("href"):
+                # in the chunked HTML document ps3.3.html list of table anchors, hrefs are of the form filename#table_id
+                href = anchor.get("href")
+                text = anchor.get_text(strip=True)
+
+                # Check if this is an IOD Modules table
+                if "IOD Modules" in text:
+                    # Extract table ID from href (after the #)
+                    if "#" in href:
+                        table_id = href.split("#")[-1]
+                        table_url = urljoin(base_url, href)
+                    else:
+                        table_id = "table_id_not_found"
+                        self.logger.warning(f"Table ID not found in href: {href}")
+
+                    # Extract the title (remove the table number prefix)
+                    title_match = re.match(r"^[A-Z]?\.\d+(?:\.\d+)*-\d+\.\s*(.+)$", text)
+                    title = title_match[1] if title_match else text
+
+                    # Strip " IOD Modules" from the end of the title
+                    if title.endswith(" IOD Modules"):
+                        iod_name = title[:-12]  # Remove " IOD Modules" (12 characters)
+
+                    # Determine IOD kind based on table_id
+                    if "_A." in table_id:
+                        iod_kind = "Composite"
+                    elif "_B." in table_id:
+                        iod_kind = "Normalized"
+                    else:
+                        iod_kind = "Other"
+
+                    iod_entry_list.append(IODEntry(iod_name, table_id, table_url, iod_kind))
+
+        return iod_entry_list

--- a/src/dcmspec_explorer/services/iod_loading_service.py
+++ b/src/dcmspec_explorer/services/iod_loading_service.py
@@ -11,18 +11,22 @@ from dcmspec_explorer.services.progress_observer import ServiceProgressObserver
 class IODListLoaderWorker:
     """Load IOD list in a background thread."""
 
-    def __init__(self, model: Any, logger: logging.Logger, event_queue: queue.Queue) -> None:
+    def __init__(
+        self, model: Any, logger: logging.Logger, event_queue: queue.Queue, force_download: bool = False
+    ) -> None:
         """Initialize the worker with the model to load IOD list.
 
         Args:
             model: The model instance to use for loading the IOD list.
             logger: The logger instance for logging progress and errors.
             event_queue: The event queue to put progress updates into.
+            force_download: Whether to force download from the web.
 
         """
         self.model = model
         self.logger = logger
         self.event_queue = event_queue
+        self.force_download = force_download
 
     def run(self) -> None:
         """Run the worker to load IOD list and send events to the event queue."""
@@ -33,7 +37,9 @@ class IODListLoaderWorker:
         progress_observer = ServiceProgressObserver(self.event_queue)
 
         try:
-            iod_entry_list = self.model.load_iod_list(progress_observer=progress_observer)
+            iod_entry_list = self.model.load_iod_list(
+                force_download=self.force_download, progress_observer=progress_observer
+            )
             self.event_queue.put(("loaded", iod_entry_list))
         except Exception as e:
             self.event_queue.put(("error", str(e)))

--- a/src/dcmspec_explorer/services/service_mediator.py
+++ b/src/dcmspec_explorer/services/service_mediator.py
@@ -55,10 +55,10 @@ class BaseServiceMediator(QObject):
         self._thread = None
         self._poll_timer = None
 
-    def start_worker(self, worker_cls: type, *worker_args: Any) -> Tuple[Any, threading.Thread]:
+    def start_worker(self, worker_cls: type, **worker_kwargs: Any) -> Tuple[Any, threading.Thread]:
         """Start the given worker in a background thread and begin polling its event queue."""
         self._event_queue = queue.Queue()
-        self._worker = worker_cls(*worker_args, logger=self.logger, event_queue=self._event_queue)
+        self._worker = worker_cls(logger=self.logger, event_queue=self._event_queue, **worker_kwargs)
         self._thread = threading.Thread(target=self._worker.run, daemon=True)
         self._thread.start()
 
@@ -108,9 +108,9 @@ class IODListLoaderServiceMediator(BaseServiceMediator):
             "error": (self.iodlist_error_signal, True),
         }
 
-    def start_iodlist_worker(self) -> Tuple[IODListLoaderWorker, threading.Thread]:
+    def start_iodlist_worker(self, force_download: bool = False) -> Tuple[IODListLoaderWorker, threading.Thread]:
         """Start the IOD list loader worker in a background thread."""
-        return self.start_worker(IODListLoaderWorker, self.model)
+        return self.start_worker(IODListLoaderWorker, model=self.model, force_download=force_download)
 
 
 class IODModelLoaderServiceMediator(BaseServiceMediator):
@@ -132,4 +132,4 @@ class IODModelLoaderServiceMediator(BaseServiceMediator):
 
     def start_iodmodel_worker(self, table_id: str) -> Tuple[IODModelLoaderWorker, threading.Thread]:
         """Start the IOD model loader worker in a background thread."""
-        return self.start_worker(IODModelLoaderWorker, self.model, table_id)
+        return self.start_worker(IODModelLoaderWorker, model=self.model, table_id=table_id)

--- a/src/dcmspec_explorer/view/main_window.py
+++ b/src/dcmspec_explorer/view/main_window.py
@@ -32,6 +32,7 @@ class MainWindow(QMainWindow):
     header_clicked = Signal(int)  # signal payload is clicked column index
     search_text_changed = Signal(str)  # signal payload is search box text
     toggle_favorites_clicked = Signal()  # signal for Show All / Show Favorites button
+    reload_clicked = Signal()  # signal for Reload button
 
     def __init__(self):
         """Initialize the main window using compiled UI from Qt Designer.
@@ -86,6 +87,7 @@ class MainWindow(QMainWindow):
         self.ui.searchLineEdit.textChanged.connect(self._on_search_text_changed)
         header.sectionClicked.connect(self._on_treeview_header_clicked)
         self.ui.toggleFavoritesPushButton.clicked.connect(self._on_toggle_favorites_clicked)
+        self.ui.reloadPushButton.clicked.connect(self._on_reload_clicked)
 
     def get_portable_monospace_font(self, size: Optional[int] = None) -> QFont:
         """Get a monospace font that is likely to be available on most platforms."""
@@ -157,6 +159,10 @@ class MainWindow(QMainWindow):
     def _on_toggle_favorites_clicked(self):
         """Emit a custom signal when the Show All / Show Favorites button is clicked."""
         self.toggle_favorites_clicked.emit()
+
+    def _on_reload_clicked(self):
+        """Emit a custom signal when the Reload button is clicked."""
+        self.reload_clicked.emit()
 
     def set_show_favorites_button_label(self, show_favorites: bool):
         """Set the label of the Show All / Show Favorites button."""


### PR DESCRIPTION
- Connect existing Reload button to controller logic and custom signal.
- On reload, force download the IOD list and detect DICOM version changes.
- If a new version is detected, move previous cache files to a versioned subfolder.
- Add a model flag to indicate when a new version is available.
- Update IOD list loader worker and service mediator to support force_download.
- Repopulate treeview children with previously loaded IODs only if the version is unchanged.
- Add helper methods to avoid duplicate signal connections.

## Summary by Sourcery

Implement a version-aware reload workflow that ties the Reload UI button to controller logic, forces download of the IOD list, detects DICOM version updates, and archives old cache directories accordingly

New Features:
- Add a Reload button handler to force-download the IOD list from the web
- Detect and expose new DICOM standard version changes via a model flag

Enhancements:
- Archive previous cache directories into versioned subfolders when a new version is detected
- Refactor signal connection logic to safely (re)connect IOD list loader signals
- Propagate a force_download flag through the service mediator and loader worker