### PR TITLE
Display module references as clickable links in details panel

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -190,7 +190,7 @@ pdf = ["camelot-py (>=1.0.0,<2.0.0)", "opencv-python-headless (>=4.12.0.88,<5.0.
 type = "git"
 url = "https://github.com/dwikler/dcmspec.git"
 reference = "HEAD"
-resolved_reference = "8bd3e2f08ccbd432ce7955d1096427306c8ea7c4"
+resolved_reference = "d5be1621044559cbe328b0f6cb49c2af522af232"
 
 [[package]]
 name = "distlib"

--- a/src/dcmspec_explorer/controller/app_controller.py
+++ b/src/dcmspec_explorer/controller/app_controller.py
@@ -311,6 +311,7 @@ class AppController(QObject):
         self.view.ui.iodTreeView.expand(index)
 
     def _handle_module_item_clicked(self, selected_item_path: str, iod_kind: str) -> None:
+        # sourcery skip: assign-if-exp, extract-method, inline-immediately-returned-variable
         """Handle click on a second-level (Module) item."""
         # Get attribute details from the model using only the node_path
         details = self.model.get_node_details(selected_item_path)
@@ -320,15 +321,18 @@ class AppController(QObject):
             usage = details.get("usage", "")
             usage_display = DICOM_USAGE_MAP.get(usage, f"Other ({usage})")
             description = details.get("description", "")
+            ref_html = details.get("ref", "")
+            ref_text = self.model.get_module_ref_link(ref_html) if ref_html else ""
+
             if iod_kind == "Composite":
                 html = f"""<h1>{details.get("module", "Unknown")} Module</h1>
                     <p><span class="label">IE:</span> {ie}</p>
                     <p><span class="label">Usage:</span> {usage_display}</p>
-                    <p><span class="label">Reference:</span> {details.get("ref", "")}</p>
+                    <p><span class="label">Reference:</span> {ref_text}</p>
                     """
             else:
                 html = f"""<h1>{details.get("module", "Unknown")} Module</h1>
-                    <p><span class="label">Reference:</span> {details.get("ref", "")}</p>
+                    <p><span class="label">Reference:</span> {ref_text}</p>
                     <p><span class="label">Description:</span> {description}</p>
                     """
         else:

--- a/src/dcmspec_explorer/controller/app_controller.py
+++ b/src/dcmspec_explorer/controller/app_controller.py
@@ -311,12 +311,12 @@ class AppController(QObject):
         self.view.ui.iodTreeView.expand(index)
 
     def _handle_module_item_clicked(self, selected_item_path: str, iod_kind: str) -> None:
-        # sourcery skip: assign-if-exp, extract-method, inline-immediately-returned-variable
         """Handle click on a second-level (Module) item."""
         # Get attribute details from the model using only the node_path
         details = self.model.get_node_details(selected_item_path)
 
         if details:
+            # sourcery skip: assign-if-exp, extract-method, inline-immediately-returned-variable
             ie = details.get("ie", "Unspecified")
             usage = details.get("usage", "")
             usage_display = DICOM_USAGE_MAP.get(usage, f"Other ({usage})")

--- a/src/dcmspec_explorer/model/model.py
+++ b/src/dcmspec_explorer/model/model.py
@@ -9,8 +9,8 @@ from typing import List, NamedTuple, Tuple
 from urllib.parse import urljoin
 
 from anytree import Node
-
 from bs4 import BeautifulSoup
+
 from dcmspec.config import Config
 from dcmspec.xhtml_doc_handler import XHTMLDocHandler
 from dcmspec.dom_table_spec_parser import DOMTableSpecParser
@@ -51,6 +51,7 @@ class Model:
     """Data model for DICOM specifications."""
 
     PART3_XHTML_CACHE_FILE_NAME = "Part3.xhtml"
+    PART3_XHTML_URL = "https://dicom.nema.org/medical/dicom/current/output/html/part03.html"
 
     def __init__(self, config: Config, logger: logging.Logger):
         """Initialize the data model."""
@@ -180,7 +181,7 @@ class Model:
             or None if building failed.
 
         """
-        url = "https://dicom.nema.org/medical/dicom/current/output/html/part03.html"
+        url = self.PART3_XHTML_URL
         cache_file_name = self.PART3_XHTML_CACHE_FILE_NAME
         model_file_name = f"Part3_{table_id}_expanded.json"
 
@@ -189,13 +190,17 @@ class Model:
 
         # Create the IOD specification factory
         c_iod_columns_mapping = {0: "ie", 1: "module", 2: "ref", 3: "usage"}
+        c_iod_unformatted = {0: True, 1: True, 2: False, 3: True}
         n_iod_columns_mapping = {0: "module", 1: "ref", 2: "description"}
+        n_iod_unformatted = {0: True, 1: False, 2: True}
         iod_columns_mapping = c_iod_columns_mapping if composite_iod else n_iod_columns_mapping
+        iod_unformatted = c_iod_unformatted if composite_iod else n_iod_unformatted
         iod_factory = SpecFactory(
             column_to_attr=iod_columns_mapping,
             name_attr="module",
             config=self.config,
             logger=logger,
+            parser_kwargs={"unformatted": iod_unformatted},
         )
 
         # Create the modules specification factory
@@ -281,6 +286,19 @@ class Model:
         """
         node = self.get_node_by_path(node_path)
         return None if node is None else node.__dict__
+
+    def get_module_ref_link(self, ref_value: str) -> str:
+        """Return formatted HTML anchor for the module reference, or plain text if not available."""
+        if not ref_value:
+            return ""
+        soup = BeautifulSoup(ref_value, "xml")
+        anchor = soup.find("a", class_="xref")
+        if anchor and anchor.has_attr("href"):
+            href = anchor["href"]
+            url = f"{self.PART3_XHTML_URL}{href}" if href.startswith("#") else href
+            anchor_text = anchor.get_text(strip=True)
+            return f'<a href="{url}">{anchor_text}</a>'
+        return ref_value
 
     def _create_temp_iod_list_file(self) -> Tuple[str, str]:
         """Create a unique temp file for downloading the IOD list file in the standard cache directory.


### PR DESCRIPTION
- Update dcmspec package to latest commit
- Parse 'ref' column as HTML (unformatted=False) in model
- Add model method to format reference as link or text
- Update controller to use model for displaying reference

## Summary by Sourcery

Format module references as clickable links in the details panel by parsing raw HTML and centralising the DICOM Part 3 URL

New Features:
- Add Model.get_module_ref_link to convert raw reference HTML into clickable anchor tags
- Update controller to display formatted reference links in module details view

Enhancements:
- Introduce PART3_XHTML_URL constant and replace hard-coded URL in load_iod_model
- Enable unformatted parsing for the "ref" column when instantiating SpecFactory

Build:
- Update dcmspec package to latest commit in poetry.lock