### PR TITLE
Refactor model to store loaded SpecModel instances in memory

### DIFF
--- a/src/dcmspec_explorer/controller/app_controller.py
+++ b/src/dcmspec_explorer/controller/app_controller.py
@@ -146,9 +146,6 @@ class AppController(QObject):
         selected_item_name = model.itemFromIndex(index.siblingAtColumn(0))
         selected_item_kind = model.itemFromIndex(index.siblingAtColumn(1))
 
-        # Retrieve the node path from the selected item data
-        selected_item_node_path = selected_item_name.data(NODE_PATH_ROLE) if selected_item_name else None
-
         # Check the clicked item level and take appropriate action
         if index.parent().isValid() is False:
             # top-level (IOD)
@@ -156,16 +153,29 @@ class AppController(QObject):
 
         elif index.parent().parent().isValid() is False:
             # second-level (Module)
-            # Get the parent (IOD) kind from the parent row, column 1
             parent_index = index.parent()
-            model = index.model()
             parent_kind_item = model.itemFromIndex(parent_index.siblingAtColumn(1))
             iod_kind = parent_kind_item.text() if parent_kind_item else "Unknown"
-            self._handle_module_item_clicked(selected_item_node_path, iod_kind)
+            details = self.get_specmodel_details(selected_item_name)
+            self._handle_module_item_clicked(details, iod_kind)
 
         else:
             # third-level (Attribute)
-            self._handle_attribute_item_clicked(selected_item_node_path)
+            details = self.get_specmodel_details(selected_item_name)
+            self._handle_attribute_item_clicked(details)
+
+    def get_specmodel_details(self, selected_item):
+        """Return the details dict for a node in the SpecModel tree given a QStandardItem."""
+        table_id = self.treeview_adapter.get_table_id_for_item(selected_item)
+        full_path = selected_item.data(NODE_PATH_ROLE) or ""
+        path_parts = full_path.split("/") if full_path else []
+        # Skip "content" if present
+        if path_parts and path_parts[0] == "content":
+            relative_path = "/".join(path_parts[1:])
+        else:
+            relative_path = full_path
+        node = self.model.get_specmodel_node(table_id, relative_path)
+        return node.__dict__ if node else None
 
     def _on_treeview_right_click(self, index: QModelIndex, global_pos):
         """Show context menu for favorites management on top-level items."""
@@ -310,13 +320,9 @@ class AppController(QObject):
         # Set expand property for the selected iod item in the view (will be effective when item will be populated)
         self.view.ui.iodTreeView.expand(index)
 
-    def _handle_module_item_clicked(self, selected_item_path: str, iod_kind: str) -> None:
+    def _handle_module_item_clicked(self, details: dict, iod_kind: str) -> None:
         """Handle click on a second-level (Module) item."""
-        # Get attribute details from the model using only the node_path
-        details = self.model.get_node_details(selected_item_path)
-
         if details:
-            # sourcery skip: assign-if-exp, extract-method, inline-immediately-returned-variable
             ie = details.get("ie", "Unspecified")
             usage = details.get("usage", "")
             usage_display = DICOM_USAGE_MAP.get(usage, f"Other ({usage})")
@@ -336,15 +342,12 @@ class AppController(QObject):
                     <p><span class="label">Description:</span> {description}</p>
                     """
         else:
-            # Fallback: only show the attribute path
-            html = f"""<h1>{selected_item_path} Module</h1>"""
+            # Fallback: only show the attribute
+            html = "<h1>Module</h1>"
         self.view.set_details_html(html)
 
-    def _handle_attribute_item_clicked(self, selected_item_path: str) -> None:
+    def _handle_attribute_item_clicked(self, details: dict) -> None:
         """Handle click on a third-level or deeper (Attribute) item."""
-        # Get attribute details from the model using only the node_path
-        details = self.model.get_node_details(selected_item_path)
-
         if details:
             elem_type = details.get("elem_type", "Unspecified")
             type_display = DICOM_TYPE_MAP.get(elem_type, f"Other ({elem_type})")
@@ -354,8 +357,8 @@ class AppController(QObject):
                 <p><span class="label">Description:</span> {details.get("elem_description", "")}</p>
                 """
         else:
-            # Fallback: only show the attribute path
-            html = f"""<h1>{selected_item_path} Attribute</h1>"""
+            # Fallback: only show the attribute
+            html = "<h1>Attribute</h1>"
         self.view.set_details_html(html)
 
     def _handle_iodlist_progress(self, sender: object, progress: Progress) -> None:
@@ -368,25 +371,15 @@ class AppController(QObject):
             self.view.update_status_bar(f"Loading IOD modules... {percent}%")
 
     def _handle_iodlist_loaded(self, sender: object, iod_entry_list: list[IODEntry]) -> None:
-        # Save the mapping of already loaded iods (AnyTree node content added to treeview) by their table_id
-        loaded_children = getattr(self, "_iod_children_loaded", {}).copy()
-
-        # Initialize the mapping for this session
-        self._iod_children_loaded = {}
-
         # Populate the tree model with the loaded IODs applying filters and sorting
         self.apply_filter_and_sort(iod_entry_list=iod_entry_list)
 
-        # After repopulating the treeview, re-add children for IODs by reloading from the model
+        # After repopulating the treeview, re-add children for IODs by using the loaded SpecModels
         if not self.model.new_version_available:
             model = self.view.ui.iodTreeView.model()
-            for table_id in loaded_children.keys():
-                # Reload the IOD model (from cache if available)
-                iod_model = self.model.load_iod_model(table_id, self.logger)
+            for table_id, iod_model in self.model._iod_specmodels.items():
                 if iod_model and hasattr(iod_model, "content") and iod_model.content:
-                    self.model.add_iod_spec_content(table_id, iod_model.content)
                     IODTreeViewModelAdapter.populate_iod_entry_children(model, table_id, iod_model.content)
-                    self._iod_children_loaded[table_id] = iod_model.content
 
         # Update the version label with the model's version
         if self.model.version:
@@ -414,14 +407,6 @@ class AppController(QObject):
 
     def _handle_iodmodel_loaded(self, sender: object, iod_model: object, table_id: str) -> None:
         if iod_model and hasattr(iod_model, "content"):
-            # Add the loaded IOD content to the model
-            self.model.add_iod_spec_content(table_id, iod_model.content)
-
-            # Remember that this IOD's children are loaded
-            if not hasattr(self, "_iod_children_loaded"):
-                self._iod_children_loaded = {}
-            self._iod_children_loaded[table_id] = iod_model.content
-
             # Find the parent item in the current treeview model
             model = self.view.ui.iodTreeView.model()
             success = IODTreeViewModelAdapter.populate_iod_entry_children(model, table_id, iod_model.content)
@@ -475,14 +460,13 @@ class AppController(QObject):
         search_text = self.view.ui.searchLineEdit.text()
         sort_column = self.sort_column
         sort_reverse = self.sort_reverse
-        loaded_children = getattr(self, "_iod_children_loaded", {})
 
         qt_tree_model, selected_row = self.treeview_adapter.build_treeview_model(
             iod_entry_list=iod_entry_list_to_display,
+            model=self.model,
             search_text=search_text,
             sort_column=sort_column,
             sort_reverse=sort_reverse,
-            loaded_children=loaded_children,
             selected_table_id=selected_table_id,
         )
 

--- a/src/dcmspec_explorer/controller/iod_treeview_adapter.py
+++ b/src/dcmspec_explorer/controller/iod_treeview_adapter.py
@@ -5,7 +5,7 @@ from anytree import PreOrderIter, Node
 
 from PySide6.QtGui import QStandardItemModel, QStandardItem, QIcon
 
-from dcmspec_explorer.model.model import IODEntry
+from dcmspec_explorer.model.model import IODEntry, Model
 from dcmspec_explorer.qt.qt_roles import TABLE_ID_ROLE, TABLE_URL_ROLE, NODE_PATH_ROLE, IS_FAVORITE_ROLE
 
 # Define mapping of column names to their indices
@@ -25,13 +25,23 @@ class IODTreeViewModelAdapter:
         self.favorites_manager = favorites_manager
         self.heart_icon = heart_icon
 
+    @staticmethod
+    def get_table_id_for_item(item: QStandardItem) -> Optional[str]:
+        """Walk up the treeview item chain to find the table_id from the top-level IOD item."""
+        while item is not None:
+            table_id = item.data(TABLE_ID_ROLE)
+            if table_id:
+                return table_id
+            item = item.parent()
+        return None
+
     def build_treeview_model(
         self,
         iod_entry_list: List[IODEntry],
+        model: Model,
         search_text: str = "",
         sort_column: Optional[int] = None,
         sort_reverse: bool = False,
-        loaded_children: Optional[dict] = None,
         selected_table_id: Optional[str] = None,
     ) -> Tuple[QStandardItemModel, Optional[int]]:
         """Build a QStandardItemModel for the treeview.
@@ -41,10 +51,10 @@ class IODTreeViewModelAdapter:
 
         Args:
             iod_entry_list (List[IODEntry]): The list of IOD entries to display.
+            model (Model): The main data model containing already loaded IOD SpecModels.
             search_text (str, optional): Text to filter the displayed entries.
             sort_column (int, optional): Column index to sort by.
             sort_reverse (bool, optional): Whether to reverse the sort order.
-            loaded_children (dict, optional): Preloaded child items for the tree.
             selected_table_id (str, optional): Table ID of the selected item.
 
         Returns:
@@ -76,16 +86,23 @@ class IODTreeViewModelAdapter:
                 )
             # No else needed as sorting on other columns is not supported
 
-        model = self.populate_treeview_model_top_level(filtered)
+        # Get already loaded IODs from the model's _iod_specmodels
+        loaded_children = {
+            table_id: iod_model.content
+            for table_id, iod_model in getattr(model, "_iod_specmodels", {}).items()
+            if hasattr(iod_model, "content") and iod_model.content
+        }
+
+        treeview_model = self.populate_treeview_model_top_level(filtered)
         selected_row = None
-        for row in range(model.rowCount()):
-            item = model.item(row, 0)
+        for row in range(treeview_model.rowCount()):
+            item = treeview_model.item(row, 0)
             table_id = item.data(TABLE_ID_ROLE)
             if loaded_children and table_id in loaded_children:
                 self.populate_treeview_model_item(item, loaded_children[table_id])
             if selected_table_id and table_id == selected_table_id:
                 selected_row = row
-        return model, selected_row
+        return treeview_model, selected_row
 
     def populate_treeview_model_top_level(self, iod_list: List[IODEntry]) -> QStandardItemModel:
         """Convert a list of IODEntry objects into a QStandardItemModel for use with a QTreeView.


### PR DESCRIPTION
- Add _iod_specmodels: a dict mapping table_id to loaded SpecModel instances, enabling in-memory access to full module/attribute trees.
- Remove all usage of AnyTree root node (_iod_root) and AnyTree nodes for top-level IODs.
- Replace _iod_dict with _iod_entries, a dict mapping table_id to IODEntry objects.
- Simplify iod_list property and _build_iods_model to use IODEntry objects directly.
- Update all docstrings, comments, and type hints.
- Update controller and treeview adapter to use _iod_entries for top-level IOD lookup and display.
- Update controller and treeview adapter to use _iod_specmodels for module/attribute population and details lookup.