### PR TITLE
Fix uncought refactoring regression

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,3 +17,9 @@ repos:
         # Run the formatter.
       - id: ruff-format
         args: [--line-length=120]
+
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.8.0
+    hooks:
+      - id: mypy
+        args: [--ignore-missing-imports]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,3 +46,8 @@ ignore = ["D203", "D213"]
 [tool.ruff.lint.per-file-ignores]
 # Ignore `D104` (Missing docstring in public package) in all `__init__.py` files.
 "__init__.py" = ["D104"]
+
+[tool.mypy]
+python_version = "3.12"
+ignore_missing_imports = true
+disallow_untyped_defs = false

--- a/src/dcmspec_explorer/controller/app_controller.py
+++ b/src/dcmspec_explorer/controller/app_controller.py
@@ -465,7 +465,7 @@ class AppController(QObject):
 
         qt_tree_model, selected_row = self.treeview_adapter.build_treeview_model(
             iod_entry_list=iod_entry_list_to_display,
-            model=self.model,
+            data_model=self.model,
             search_text=search_text,
             sort_column=sort_column,
             sort_reverse=sort_reverse,

--- a/src/dcmspec_explorer/controller/iod_treeview_adapter.py
+++ b/src/dcmspec_explorer/controller/iod_treeview_adapter.py
@@ -6,6 +6,7 @@ from anytree import PreOrderIter, Node
 from PySide6.QtGui import QStandardItemModel, QStandardItem, QIcon
 
 from dcmspec_explorer.model.model import IODEntry, Model
+from dcmspec_explorer.services.favorites_manager import FavoritesManager
 from dcmspec_explorer.qt.qt_roles import TABLE_ID_ROLE, TABLE_URL_ROLE, NODE_PATH_ROLE, IS_FAVORITE_ROLE
 
 # Define mapping of column names to their indices
@@ -20,7 +21,7 @@ COLUMN_INDEX = {
 class IODTreeViewModelAdapter:
     """Adapt IOD data model to Qt treeview model."""
 
-    def __init__(self, favorites_manager: object = None, heart_icon: Optional[QIcon] = None):
+    def __init__(self, favorites_manager: Optional[FavoritesManager] = None, heart_icon: Optional[QIcon] = None):
         """Initialize the adapter with an optional favorites manager."""
         self.favorites_manager = favorites_manager
         self.heart_icon = heart_icon
@@ -161,7 +162,7 @@ class IODTreeViewModelAdapter:
         if not content:
             return
 
-        tree_items = {}  # Map from node to QStandardItem for building hierarchy
+        tree_items: dict[Node, QStandardItem] = {}  # Map from node to QStandardItem for building hierarchy
 
         for node in PreOrderIter(content):
             if node == content:

--- a/src/dcmspec_explorer/services/service_mediator.py
+++ b/src/dcmspec_explorer/services/service_mediator.py
@@ -61,11 +61,11 @@ class BaseServiceMediator(QObject):
         try:
             self._worker = worker_cls(logger=self.logger, event_queue=self._event_queue, **worker_kwargs)
         except Exception as exc:
-            self.logger.exception("Failed to instantiate worker: %s", worker_cls.__name__)
+            self.logger.exception(f"Failed to instantiate worker: {worker_cls.__name__}")
             raise RuntimeError(f"Worker could not be instantiated: {worker_cls.__name__}") from exc
 
         if self._worker is None:
-            self.logger.error("Worker class %s returned None on instantiation.", worker_cls.__name__)
+            self.logger.error(f"Worker class {worker_cls.__name__} returned None on instantiation.")
             raise RuntimeError(f"Worker could not be instantiated: {worker_cls.__name__}")
 
         self._thread = threading.Thread(target=self._worker.run, daemon=True)

--- a/src/dcmspec_explorer/services/service_mediator.py
+++ b/src/dcmspec_explorer/services/service_mediator.py
@@ -50,18 +50,20 @@ class BaseServiceMediator(QObject):
         self.model = model
         self.logger = logger
 
-        self._event_queue = None
-        self._worker = None
-        self._thread = None
-        self._poll_timer = None
+        self._event_queue: Optional[queue.Queue] = None
+        self._worker: Optional[Any] = None
+        self._thread: Optional[threading.Thread] = None
+        self._poll_timer: Optional[QTimer] = None
 
     def start_worker(self, worker_cls: type, **worker_kwargs: Any) -> Tuple[Any, threading.Thread]:
         """Start the given worker in a background thread and begin polling its event queue."""
         self._event_queue = queue.Queue()
         self._worker = worker_cls(logger=self.logger, event_queue=self._event_queue, **worker_kwargs)
+        if self._worker is None:
+            raise RuntimeError("Worker could not be instantiated.")
+
         self._thread = threading.Thread(target=self._worker.run, daemon=True)
         self._thread.start()
-
         self._poll_timer = QTimer(self)
         self._poll_timer.timeout.connect(self._poll_event_queue)
         self._poll_timer.start(50)
@@ -77,7 +79,8 @@ class BaseServiceMediator(QObject):
                 signal.emit(self, data)
                 if should_cleanup:
                     self.cleanup_worker_thread()
-                    self._poll_timer.stop()
+                    if self._poll_timer is not None:
+                        self._poll_timer.stop()
 
     def cleanup_worker_thread(self) -> None:
         """Clean up the worker and its thread after completion or error."""


### PR DESCRIPTION
- Update call to build_treeview_model in AppController.apply_filter_and_sort to use data_model=self.model instead of model=self.model.

## Summary by Sourcery

Fix a parameter regression in treeview model building, improve type annotations and internal APIs, and add mypy linting.

New Features:
- Add mypy pre-commit hook for static type checking

Bug Fixes:
- Fix call to build_treeview_model to use data_model instead of model

Enhancements:
- Add Optional and dict[str, ...] type annotations across model, controller, and service mediator
- Rename get_node_details to get_node_public_attrs and get_specmodel_details to get_selected_item_details for clearer APIs
- Introduce progress_dialog attribute in AppController and runtime check for worker instantiation in ServiceMediator
- Guard stopping of QTimer in ServiceMediator

Build:
- Configure mypy in pyproject.toml

CI:
- Add mypy hook in pre-commit-config.yaml