### PR TITLE
Update for dcmspec v0.2.0

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -165,7 +165,7 @@ files = [
 
 [[package]]
 name = "dcmspec"
-version = "0.1.0"
+version = "0.2.0"
 description = ""
 optional = false
 python-versions = ">=3.12,<4.0"
@@ -190,7 +190,7 @@ pdf = ["camelot-py (>=1.0.0,<2.0.0)", "opencv-python-headless (>=4.12.0.88,<5.0.
 type = "git"
 url = "https://github.com/dwikler/dcmspec.git"
 reference = "HEAD"
-resolved_reference = "d5be1621044559cbe328b0f6cb49c2af522af232"
+resolved_reference = "03690b3e70d452289f30ff62e78c189a55345c63"
 
 [[package]]
 name = "distlib"

--- a/src/dcmspec_explorer/model/model.py
+++ b/src/dcmspec_explorer/model/model.py
@@ -241,7 +241,7 @@ class Model:
         )
 
         # Build and store the model in memory
-        iod_model = builder.build_from_url(
+        iod_model, _ = builder.build_from_url(
             url=url,
             cache_file_name=cache_file_name,
             json_file_name=model_file_name,
@@ -249,6 +249,15 @@ class Model:
             force_download=False,
             progress_observer=progress_observer,
         )
+        # Type and attribute checks to ensure the returned object is as expected.
+        if not isinstance(iod_model, SpecModel):
+            self.logger.error(f"Unexpected return type: {type(iod_model)} (expected SpecModel)")
+            raise RuntimeError("build_from_url did not return a SpecModel instance as first tuple element")
+        if not hasattr(iod_model, "content"):
+            self.logger.error(f"Returned SpecModel is missing 'content' attribute: {type(iod_model)}")
+            raise RuntimeError("Returned SpecModel is missing 'content' attribute")
+
+        # Store the loaded model in memory
         self._iod_specmodels[table_id] = iod_model
 
         return iod_model

--- a/src/dcmspec_explorer/model/model.py
+++ b/src/dcmspec_explorer/model/model.py
@@ -241,21 +241,40 @@ class Model:
         )
 
         # Build and store the model in memory
-        iod_model, _ = builder.build_from_url(
-            url=url,
-            cache_file_name=cache_file_name,
-            json_file_name=model_file_name,
-            table_id=table_id,
-            force_download=False,
-            progress_observer=progress_observer,
-        )
+        try:
+            iod_model, _ = builder.build_from_url(
+                url=url,
+                cache_file_name=cache_file_name,
+                json_file_name=model_file_name,
+                table_id=table_id,
+                force_download=False,
+                progress_observer=progress_observer,
+            )
+        except ValueError as ve:
+            self.logger.error(
+                f"Error unpacking result from build_from_url for table_id '{table_id}', url '{url}': {ve}. "
+                "The returned value did not match the expected tuple shape (SpecModel, ...)."
+            )
+            raise RuntimeError("Failed to load the DICOM model. Please try again or contact support.") from ve
+
         # Type and attribute checks to ensure the returned object is as expected.
         if not isinstance(iod_model, SpecModel):
-            self.logger.error(f"Unexpected return type: {type(iod_model)} (expected SpecModel)")
-            raise RuntimeError("build_from_url did not return a SpecModel instance as first tuple element")
+            self.logger.error(
+                f"Unexpected return type for table_id '{table_id}', url '{url}': {type(iod_model)} (expected SpecModel)"
+            )
+            raise TypeError(
+                "The selected DICOM model could not be loaded. This may be due to a corrupted file or network issue."
+            )
         if not hasattr(iod_model, "content"):
-            self.logger.error(f"Returned SpecModel is missing 'content' attribute: {type(iod_model)}")
-            raise RuntimeError("Returned SpecModel is missing 'content' attribute")
+            self.logger.error(
+                (
+                    f"Returned SpecModel is missing 'content' attribute for table_id '{table_id}', "
+                    f"url '{url}': {type(iod_model)}"
+                )
+            )
+            raise RuntimeError(
+                "The IOD was loaded, but its content could not be accessed. The content may be incomplete or corrupted."
+            )
 
         # Store the loaded model in memory
         self._iod_specmodels[table_id] = iod_model


### PR DESCRIPTION
- Unpack tuple return from build_from_url and add robust type checks

## Summary by Sourcery

Unpack the tuple returned by build_from_url, add checks to validate the returned SpecModel instance, and update the lock file for dcmspec v0.2.0.

Enhancements:
- Unpack the tuple returned by builder.build_from_url and add runtime type and attribute validations on the returned SpecModel

Build:
- Update poetry.lock for dcmspec v0.2.0 dependency